### PR TITLE
Feat file backed dict

### DIFF
--- a/src/device_spinner/file_backed_dict.py
+++ b/src/device_spinner/file_backed_dict.py
@@ -1,4 +1,4 @@
-"""Nested Saveable Dict vibe-coded with Gemini"""
+"""A nested saveable dict vibe-coded with Gemini"""
 from collections import UserDict
 from pathlib import Path
 import secrets
@@ -14,6 +14,19 @@ SupportedFormat = Literal['json', 'yaml']
 class FileBackedDict(UserDict[str, Any]):
     """Dict with a `save()` method that propagates to subdicts originating from
     the same file source.
+
+    Key Features
+    ------------
+
+    - `FileBackedDicts` are dict-like objects that are created from file (yaml or json)
+    - Once loaded from a file, `FileBackedDicts` can be manipulated like dicts.
+    - `FileBackedDicts` can contain `FileBackedDicts` ("subdicts"). These subdicts
+      have their own `save()` method.
+        - Calling `save()` from a subdict only saves the keys/values in the scope
+          of the subdict to the original file.
+        - Calling `save()` from a parent dict also saves any keys/values altered
+          by the child. (This is consistent with how normal dicts work.)
+        - `FileBackedDicts` can be converted to plain dictionaries with `to_dict()`.
     """
     def __init__(self, filepath: Union[str, Path], *args: Any,
                  _root_saver: Optional[SaverCallback] = None,
@@ -72,11 +85,13 @@ class FileBackedDict(UserDict[str, Any]):
         saver: SaverCallback = self._root_saver if self._root_saver else self._save_partial
         if isinstance(value, dict) and not isinstance(value, FileBackedDict):
             child_path: KeyPath = self._key_path + [key]
-            value = FileBackedDict(self.filepath, value, _root_saver=saver, _key_path=child_path)
+            value = FileBackedDict(self.filepath, value, _root_saver=saver,
+                                   _key_path=child_path)
         super().__setitem__(key, value)
 
     def to_dict(self) -> Dict[str, Any]:
-        """Recursively converts FileBackedDict instances back to primitive dictionaries."""
+        """Recursively converts FileBackedDict instances back to primitive
+        dictionaries."""
         result: Dict[str, Any] = {}
         for key, value in self.data.items():
             if isinstance(value, FileBackedDict):
@@ -85,7 +100,8 @@ class FileBackedDict(UserDict[str, Any]):
                 result[key] = value
         return result
 
-    def _save_partial(self, target_path: Optional[KeyPath] = None, partial_data: Optional[Dict[str, Any]] = None) -> None:
+    def _save_partial(self, target_path: Optional[KeyPath] = None,
+                      partial_data: Optional[Dict[str, Any]] = None) -> None:
         """
         Loads the file from disk, updates only the targeted subset fields,
         and saves it back using an atomic write strategy.
@@ -109,7 +125,8 @@ class FileBackedDict(UserDict[str, Any]):
         if fmt == 'json':
             output: str = json.dumps(full_data, indent=4)
         elif fmt == 'yaml':
-            output = yaml.safe_dump(full_data, default_flow_style=False, sort_keys=False)
+            output = yaml.safe_dump(full_data, default_flow_style=False,
+                                    sort_keys=False)
 
         # Ensure target directory exists
         self.filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -133,7 +150,10 @@ class FileBackedDict(UserDict[str, Any]):
             raise
 
     def save(self) -> None:
-        """Triggers a partial save targeting only this instance's keys."""
+        """Saves all keys/values back to the original file. If this instance
+        is a child, save only the keys/values in this child and leave parent
+        values unaltered."""
+        # Triggers a partial save targeting only this instance's keys.
         if self._root_saver:
             self._root_saver(self._key_path, self.to_dict())
         else:

--- a/src/device_spinner/file_backed_dict.py
+++ b/src/device_spinner/file_backed_dict.py
@@ -1,0 +1,140 @@
+"""Nested Saveable Dict vibe-coded with Gemini"""
+from collections import UserDict
+from pathlib import Path
+import secrets
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
+import json
+import yaml
+
+# Define types for paths and saving callbacks
+KeyPath = List[str]
+SaverCallback = Callable[[Optional[KeyPath], Optional[Dict[str, Any]]], None]
+SupportedFormat = Literal['json', 'yaml']
+
+class FileBackedDict(UserDict[str, Any]):
+    """Dict with a `save()` method that propagates to subdicts originating from
+    the same file source.
+    """
+    def __init__(self, filepath: Union[str, Path], *args: Any,
+                 _root_saver: Optional[SaverCallback] = None,
+                 _key_path: Optional[KeyPath] = None, **kwargs: Any) -> None:
+        self.filepath: Path = Path(filepath)
+        self._root_saver: Optional[SaverCallback] = _root_saver
+        self._key_path: KeyPath = _key_path or []
+
+        initial_data: Dict[str, Any] = {}
+        if _root_saver is not None:
+            initial_data = {}
+        elif self.filepath.exists():
+            initial_data = self._load_from_file()
+        else:
+            initial_data = {}
+
+        initial_data.update(dict(*args, **kwargs))
+        super().__init__(initial_data)
+        self._convert_nested()
+
+    def _get_format(self) -> SupportedFormat:
+        """Detects format based on file extension using pathlib."""
+        ext: str = self.filepath.suffix.lower()
+        if ext == '.json':
+            return 'json'
+        elif ext in ('.yaml', '.yml'):
+            return 'yaml'
+        raise ValueError(f"Unsupported file extension: '{ext}'. Use .json, .yaml, or .yml")
+
+    def _load_from_file(self) -> Dict[str, Any]:
+        """Reads and parses data based on the file type."""
+        fmt: SupportedFormat = self._get_format()
+        try:
+            content: str = self.filepath.read_text(encoding='utf-8')
+            if fmt == 'json':
+                data = json.loads(content)
+                return data if isinstance(data, dict) else {}
+            elif fmt == 'yaml':
+                data = yaml.safe_load(content)
+                return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, yaml.YAMLError, OSError):
+            return {}
+        return {}
+
+    def _convert_nested(self) -> None:
+        """Wraps plain dictionaries inside this dict as child instances."""
+        saver: SaverCallback = self._root_saver if self._root_saver else self._save_partial
+        for key, value in list(self.data.items()):
+            if isinstance(value, dict) and not isinstance(value, FileBackedDict):
+                child_path: KeyPath = self._key_path + [key]
+                self.data[key] = FileBackedDict(
+                    self.filepath, value, _root_saver=saver, _key_path=child_path
+                )
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        saver: SaverCallback = self._root_saver if self._root_saver else self._save_partial
+        if isinstance(value, dict) and not isinstance(value, FileBackedDict):
+            child_path: KeyPath = self._key_path + [key]
+            value = FileBackedDict(self.filepath, value, _root_saver=saver, _key_path=child_path)
+        super().__setitem__(key, value)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Recursively converts FileBackedDict instances back to primitive dictionaries."""
+        result: Dict[str, Any] = {}
+        for key, value in self.data.items():
+            if isinstance(value, FileBackedDict):
+                result[key] = value.to_dict()
+            else:
+                result[key] = value
+        return result
+
+    def _save_partial(self, target_path: Optional[KeyPath] = None, partial_data: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Loads the file from disk, updates only the targeted subset fields,
+        and saves it back using an atomic write strategy.
+        """
+        full_data: Dict[str, Any] = self._load_from_file() if self.filepath.exists() else {}
+
+        if target_path and partial_data is not None:
+            current: Any = full_data
+            for step in target_path[:-1]:
+                if step not in current or not isinstance(current[step], dict):
+                    current[step] = {}
+                current = current[step]
+
+            if target_path:
+                current[target_path[-1]] = partial_data
+        else:
+            full_data = self.to_dict()
+
+        fmt: SupportedFormat = self._get_format()
+
+        if fmt == 'json':
+            output: str = json.dumps(full_data, indent=4)
+        elif fmt == 'yaml':
+            output = yaml.safe_dump(full_data, default_flow_style=False, sort_keys=False)
+
+        # Ensure target directory exists
+        self.filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        # --- ATOMIC WRITE ---
+        # Generate a unique temp file name in the target directory to guarantee
+        # they're on the same filesystem
+        temp_suffix = f".tmp_{secrets.token_hex(4)}"
+        temp_file = self.filepath.with_suffix(self.filepath.suffix + temp_suffix)
+
+        try:
+            # 1. Write data to the temporary file completely
+            temp_file.write_text(output, encoding='utf-8')
+
+            # 2. Atomically swap/replace the temp file over the target destination file
+            temp_file.replace(self.filepath)
+        except Exception:
+            # Clean up the temp file if the write process itself failed
+            if temp_file.exists():
+                temp_file.unlink()
+            raise
+
+    def save(self) -> None:
+        """Triggers a partial save targeting only this instance's keys."""
+        if self._root_saver:
+            self._root_saver(self._key_path, self.to_dict())
+        else:
+            self._save_partial()

--- a/tests/test_file_backed_dict.py
+++ b/tests/test_file_backed_dict.py
@@ -1,0 +1,97 @@
+from _pytest.nodes import File
+from device_spinner.file_backed_dict import FileBackedDict
+
+
+def get_example_file_backed_dict(tmp_path) -> FileBackedDict:
+    """Make a FileBackedDict instance from an empty config.yaml file"""
+    path = tmp_path / "config.yaml"  # Empty yaml.
+    config = FileBackedDict(path)
+    config["users"] = {"Fred": {"age": 42,
+                                "fave_recipe": {"name": "fried strings",
+                                                "ingredients": ["string", "strfry"],
+                                                "instructions": ["Saute the string.",
+                                                                 "Cool and serve."]}}}
+    return config
+
+
+def test_to_dict_comparison(tmp_path):
+    path = tmp_path / "config.yaml"  # Empty yaml.
+    config = FileBackedDict(path)
+    config["database"] = {"host": "localhost", "port": 5432}
+    config["logging"] = {"level": "INFO"}
+
+    config_dict = {"database":{"host": "localhost", "port": 5432},
+                   "logging": {"level": "INFO"}}
+    assert config.to_dict() == config_dict
+
+
+def test_parent_altering_child_scope_attributes_changes_child_attributes(tmp_path):
+    config = get_example_file_backed_dict(tmp_path)
+    # Make child.
+    freds_fave_recipe = config["users"]["Fred"]["fave_recipe"]
+    # Change child values from the parent.
+    config["users"]["Fred"]["fave_recipe"]["ingredients"][1] = "strcmp"
+    # Change should be reflected in the child.
+    assert freds_fave_recipe["ingredients"][1] == "strcmp"
+
+
+def test_child_altering_attributes_changes_same_attributes_in_parent(tmp_path):
+    config = get_example_file_backed_dict(tmp_path)
+    # Make child.
+    freds_fave_recipe = config["users"]["Fred"]["fave_recipe"]
+    # Change child values from the parent.
+    config["users"]["Fred"]["fave_recipe"]["ingredients"][1] = "strcmp"
+    # Change should be reflected in the child.
+    assert freds_fave_recipe["ingredients"][1] == "strcmp"
+
+
+def test_saving(tmp_path):
+    path = tmp_path / "config.yaml"  # Empty yaml.
+    config = FileBackedDict(path)
+    config["pockets"] = ["keys", "spare change", "the one ring"]
+    config.save()
+    # Import changes from file into a separate instance.
+    config2 = FileBackedDict(path)
+    assert config2.to_dict() == config.to_dict()
+
+
+def test_saving_child_only_saves_child_scope_changes(tmp_path):
+    config = get_example_file_backed_dict(tmp_path)
+    # Make child.
+    freds_fave_recipe = config["users"]["Fred"]["fave_recipe"]
+    # Alter child
+    freds_fave_recipe["name"] = "tomato soup"
+    # Alter parent
+    config["users"]["Frankie"] = {"age": 27,
+                                  "fave_recipe": {"name": "onion soup",
+                                                  "ingredients": ["onions", "broth"],
+                                                  "instructions": ["boil for 10 mins.",
+                                                                   "Cool and serve."]}}
+    freds_fave_recipe.save() # should not save out-of-scope changes.
+    # Import changes from file into a separate instance.
+    path = tmp_path / "config.yaml"  # recently-saved yaml
+    config2 = FileBackedDict(path)
+    assert "Frankie" not in config2.to_dict()["users"]
+
+
+def test_saving_parent_also_saves_child_scope_changes(tmp_path):
+    config = get_example_file_backed_dict(tmp_path)
+    # Make child.
+    freds_fave_recipe = config["users"]["Fred"]["fave_recipe"]
+    # Alter child
+    freds_fave_recipe["name"] = "tomato soup"
+    # Alter parent
+    config["users"]["Frankie"] = {"age": 27,
+                                  "fave_recipe": {"name": "onion soup",
+                                                  "ingredients": ["onions", "broth"],
+                                                  "instructions": ["boil for 10 mins.",
+                                                                   "Cool and serve."]}}
+    # Alter child
+    freds_fave_recipe["name"] = "string beans"
+    # Save parent
+    config.save() # should save everything.
+    # Import changes from file into a separate instance.
+    path = tmp_path / "config.yaml"  # recently-saved yaml
+    config2 = FileBackedDict(path)
+    # Child changes should exist.
+    assert config2["users"]["Fred"]["fave_recipe"]["name"] == "string beans"


### PR DESCRIPTION
Vibe-code hierarchical, saveable dict. (I made some edits and wrote the tests.) This is a useful pattern, though we might revisit it with models later. This repo seems to be the best spot for it for now.

- `FileBackedDicts` are dict-like objects that are created from file (yaml or json)
- Once loaded from a file, `FileBackedDicts` can be manipulated like dicts.
- `FileBackedDicts` can contain `FileBackedDicts` ("subdicts"). These subdicts
  have their own `save()` method.
    - Calling `save()` from a subdict only saves the keys/values in the scope
      of the subdict to the original file.
    - Calling `save()` from a parent dict also saves any keys/values altered
      by the child. (This is consistent with how normal dicts work.)
    - `FileBackedDicts` can be converted to plain dictionaries with `to_dict()`.