### PR TITLE
Separate HierarchicalDict out of FileBackedDict

### DIFF
--- a/src/device_spinner/file_backed_dict.py
+++ b/src/device_spinner/file_backed_dict.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 import secrets
-from typing import Any, Dict, Literal, Union
+from typing import Any, Dict, Literal, Optional, Union, overload
 import json
 import yaml
 
@@ -76,26 +76,63 @@ class FileBackedDict(HierarchicalDict):
     All dict behaviour is inherited from ``HierarchicalDict``. Only
     file-loading, child-creation, and persistence are overridden.
 
-    Use ``FileBackedDict.init_root(filepath)`` to create an instance.
+    Use ``FileBackedDict(filepath)`` to create an instance.
     Call ``.save()`` to write changes back and ``.load()`` to pull in
     changes from disk.
     """
 
-    @classmethod
-    def init_root(
-        cls, filepath: Union[str, Path], *args: Any, **kwargs: Any
-    ) -> "FileBackedDict":
-        """Create a root FileBackedDict backed by a file.
+    @overload
+    def __init__(
+        self,
+        *args: Any,
+        filepath: Union[str, Path],
+        **kwargs: Any,
+    ) -> None:
+        """Create a root node backed by *filepath*, loading its contents immediately.
 
-        Loads existing file contents, then applies any extra keyword or
-        positional arguments as an overlay (same semantics as ``dict.update``).
+        If the file does not exist it is created on the first call to :meth:`save`.
+        Any positional or keyword arguments are applied as an overlay on top of the
+        loaded data after the file is read.
         """
-        instance = cls()
-        instance._filepath = Path(filepath)
-        instance.load()
-        if args or kwargs:
-            instance.update(dict(*args, **kwargs))
-        return instance
+        ...
+
+    @overload
+    def __init__(
+        self,
+        *args: Any,
+        _parent: "FileBackedDict",
+        _key_in_parent: str,
+        **kwargs: Any,
+    ) -> None:
+        """Internal — do not call directly.
+
+        Child nodes are created automatically when a plain :class:`dict` is assigned
+        to a key.  They share the filepath of their root ancestor.
+        """
+        ...
+
+    def __init__(
+        self,
+        *args: Any,
+        filepath: Union[str, Path, None] = None,
+        _parent: Optional["FileBackedDict"] = None,
+        _key_in_parent: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """See the :func:`~overload` signatures above for the two supported calling
+        conventions: creating a root node bound to a file, or internal child-node
+        construction (done automatically — not intended for direct use).
+        """
+        super().__init__(
+            dict(*args, **kwargs),
+            _parent=_parent,
+            _key_in_parent=_key_in_parent,
+        )
+        if _parent is None:
+            if filepath is None:
+                raise ValueError("filepath is required for a root FileBackedDict")
+            self._filepath: Path = Path(filepath)
+            self.load()
 
     @property
     def filepath(self) -> Path:

--- a/src/device_spinner/file_backed_dict.py
+++ b/src/device_spinner/file_backed_dict.py
@@ -1,160 +1,145 @@
-"""A nested saveable dict vibe-coded with Gemini"""
-from collections import UserDict
+"""File-backed persistence utilities for HierarchicalDict."""
+
 from pathlib import Path
 import secrets
-from typing import Any, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, Literal, Union
 import json
 import yaml
 
-# Define types for paths and saving callbacks
-KeyPath = List[str]
-SaverCallback = Callable[[Optional[KeyPath], Optional[Dict[str, Any]]], None]
-SupportedFormat = Literal['json', 'yaml']
+from .hierarchical_dict import (
+    HierarchicalDict,
+    KeyPath,
+)
 
-class FileBackedDict(UserDict[str, Any]):
-    """Dict with a `save()` method that propagates to subdicts originating from
-    the same file source.
 
-    Key Features
-    ------------
+## File I/O utilities
 
-    - `FileBackedDicts` are dict-like objects that are created from file (yaml or json)
-    - Once loaded from a file, `FileBackedDicts` can be manipulated like dicts.
-    - `FileBackedDicts` can contain `FileBackedDicts` ("subdicts"). These subdicts
-      have their own `save()` method.
-        - Calling `save()` from a subdict only saves the keys/values in the scope
-          of the subdict to the original file.
-        - Calling `save()` from a parent dict also saves any keys/values altered
-          by the child. (This is consistent with how normal dicts work.)
-        - `FileBackedDicts` can be converted to plain dictionaries with `to_dict()`.
-    """
-    def __init__(self, filepath: Union[str, Path], *args: Any,
-                 _root_saver: Optional[SaverCallback] = None,
-                 _key_path: Optional[KeyPath] = None, **kwargs: Any) -> None:
-        self.filepath: Path = Path(filepath)
-        self._root_saver: Optional[SaverCallback] = _root_saver
-        self._key_path: KeyPath = _key_path or []
 
-        initial_data: Dict[str, Any] = {}
-        if _root_saver is not None:
-            initial_data = {}
-        elif self.filepath.exists():
-            initial_data = self._load_from_file()
-        else:
-            initial_data = {}
+def _set_nested(data: Dict[str, Any], path: KeyPath, value: Any) -> None:
+    """Modify data by assigning value into the nested path, creating intermediate dicts as needed."""
+    for key in path[:-1]:
+        if not isinstance(data.get(key), dict):
+            data[key] = {}
+        data = data[key]
+    data[path[-1]] = value
 
-        initial_data.update(dict(*args, **kwargs))
-        super().__init__(initial_data)
-        self._convert_nested()
 
-    def _get_format(self) -> SupportedFormat:
-        """Detects format based on file extension using pathlib."""
-        ext: str = self.filepath.suffix.lower()
-        if ext == '.json':
-            return 'json'
-        elif ext in ('.yaml', '.yml'):
-            return 'yaml'
-        raise ValueError(f"Unsupported file extension: '{ext}'. Use .json, .yaml, or .yml")
+SupportedFormat = Literal["json", "yaml"]
 
-    def _load_from_file(self) -> Dict[str, Any]:
-        """Reads and parses data based on the file type."""
-        fmt: SupportedFormat = self._get_format()
-        try:
-            content: str = self.filepath.read_text(encoding='utf-8')
-            if fmt == 'json':
-                data = json.loads(content)
-                return data if isinstance(data, dict) else {}
-            elif fmt == 'yaml':
-                data = yaml.safe_load(content)
-                return data if isinstance(data, dict) else {}
-        except (json.JSONDecodeError, yaml.YAMLError, OSError):
-            return {}
+
+def _get_format(filepath: Path) -> SupportedFormat:
+    """Detect serialisation format from file extension."""
+    ext: str = filepath.suffix.lower()
+    if ext == ".json":
+        return "json"
+    if ext in (".yaml", ".yml"):
+        return "yaml"
+    raise ValueError(f"Unsupported file extension: '{ext}'. Use .json, .yaml, or .yml")
+
+
+def _load_dict_from_file(filepath: Path) -> Dict[str, Any]:
+    """Load top-level mapping from a json/yaml file."""
+    fmt: SupportedFormat = _get_format(filepath)
+    try:
+        content: str = filepath.read_text(encoding="utf-8")
+        if fmt == "json":
+            data = json.loads(content)
+            return data if isinstance(data, dict) else {}
+        data = yaml.safe_load(content)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, yaml.YAMLError, OSError):
         return {}
 
-    def _convert_nested(self) -> None:
-        """Wraps plain dictionaries inside this dict as child instances."""
-        saver: SaverCallback = self._root_saver if self._root_saver else self._save_partial
-        for key, value in list(self.data.items()):
-            if isinstance(value, dict) and not isinstance(value, FileBackedDict):
-                child_path: KeyPath = self._key_path + [key]
-                self.data[key] = FileBackedDict(
-                    self.filepath, value, _root_saver=saver, _key_path=child_path
-                )
 
-    def __setitem__(self, key: str, value: Any) -> None:
-        saver: SaverCallback = self._root_saver if self._root_saver else self._save_partial
-        if isinstance(value, dict) and not isinstance(value, FileBackedDict):
-            child_path: KeyPath = self._key_path + [key]
-            value = FileBackedDict(self.filepath, value, _root_saver=saver,
-                                   _key_path=child_path)
-        super().__setitem__(key, value)
+def _dump_dict_to_file(filepath: Path, full_data: Dict[str, Any]) -> None:
+    """Atomically write a mapping to a json/yaml file."""
+    fmt: SupportedFormat = _get_format(filepath)
+    if fmt == "json":
+        output: str = json.dumps(full_data, indent=4)
+    else:
+        output = yaml.safe_dump(full_data, default_flow_style=False, sort_keys=False)
 
-    def to_dict(self) -> Dict[str, Any]:
-        """Recursively converts FileBackedDict instances back to primitive
-        dictionaries."""
-        result: Dict[str, Any] = {}
-        for key, value in self.data.items():
-            if isinstance(value, FileBackedDict):
-                result[key] = value.to_dict()
-            else:
-                result[key] = value
-        return result
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    temp_file = filepath.with_suffix(filepath.suffix + f".tmp_{secrets.token_hex(4)}")
+    try:
+        temp_file.write_text(output, encoding="utf-8")
+        temp_file.replace(filepath)
+    except Exception:
+        if temp_file.exists():
+            temp_file.unlink()
+        raise
 
-    def _save_partial(self, target_path: Optional[KeyPath] = None,
-                      partial_data: Optional[Dict[str, Any]] = None) -> None:
+
+class FileBackedDict(HierarchicalDict):
+    """HierarchicalDict bound to a json/yaml file.
+
+    All dict behaviour is inherited from ``HierarchicalDict``. Only
+    file-loading, child-creation, and persistence are overridden.
+
+    Use ``FileBackedDict.init_root(filepath)`` to create an instance.
+    Call ``.save()`` to write changes back and ``.load()`` to pull in
+    changes from disk.
+    """
+
+    @classmethod
+    def init_root(
+        cls, filepath: Union[str, Path], *args: Any, **kwargs: Any
+    ) -> "FileBackedDict":
+        """Create a root FileBackedDict backed by a file.
+
+        Loads existing file contents, then applies any extra keyword or
+        positional arguments as an overlay (same semantics as ``dict.update``).
         """
-        Loads the file from disk, updates only the targeted subset fields,
-        and saves it back using an atomic write strategy.
+        instance = cls()
+        instance._filepath = Path(filepath)
+        instance.load()
+        if args or kwargs:
+            instance.update(dict(*args, **kwargs))
+        return instance
+
+    @property
+    def filepath(self) -> Path:
+        """Path to the backing file. Owned by the root; children delegate upward."""
+        if self.is_root:
+            return self._filepath
+        return self._parent.filepath  # type: ignore[union-attr]
+
+    def _make_child(self, key: str, value: Dict[str, Any]) -> "FileBackedDict":
+        """Override to keep children as FileBackedDict so they share filepath."""
+        return FileBackedDict(value, _parent=self, _key_in_parent=key)
+
+    def load(self, *, replace: bool = True) -> None:
+        """Load/reload this node's scope from file.
+
+        Root node operates on the full tree; a child node operates only on its
+        own scope, leaving sibling keys in memory untouched.
+
+        Args:
+            replace: If True (default), clear in-memory keys before applying
+                file data so the result exactly mirrors the file. If False,
+                merge file data on top of memory, leaving keys absent from the
+                file untouched.
         """
-        full_data: Dict[str, Any] = self._load_from_file() if self.filepath.exists() else {}
-
-        if target_path and partial_data is not None:
-            current: Any = full_data
-            for step in target_path[:-1]:
-                if step not in current or not isinstance(current[step], dict):
-                    current[step] = {}
-                current = current[step]
-
-            if target_path:
-                current[target_path[-1]] = partial_data
-        else:
-            full_data = self.to_dict()
-
-        fmt: SupportedFormat = self._get_format()
-
-        if fmt == 'json':
-            output: str = json.dumps(full_data, indent=4)
-        elif fmt == 'yaml':
-            output = yaml.safe_dump(full_data, default_flow_style=False,
-                                    sort_keys=False)
-
-        # Ensure target directory exists
-        self.filepath.parent.mkdir(parents=True, exist_ok=True)
-
-        # --- ATOMIC WRITE ---
-        # Generate a unique temp file name in the target directory to guarantee
-        # they're on the same filesystem
-        temp_suffix = f".tmp_{secrets.token_hex(4)}"
-        temp_file = self.filepath.with_suffix(self.filepath.suffix + temp_suffix)
-
-        try:
-            # 1. Write data to the temporary file completely
-            temp_file.write_text(output, encoding='utf-8')
-
-            # 2. Atomically swap/replace the temp file over the target destination file
-            temp_file.replace(self.filepath)
-        except Exception:
-            # Clean up the temp file if the write process itself failed
-            if temp_file.exists():
-                temp_file.unlink()
-            raise
+        file_data: Dict[str, Any] = (
+            _load_dict_from_file(self.filepath) if self.filepath.exists() else {}
+        )
+        if not self.is_root:
+            for key in self._path_from_root():
+                file_data = file_data.get(key, {})
+        if replace:
+            self.data.clear()
+        self.update(file_data)
 
     def save(self) -> None:
-        """Saves all keys/values back to the original file. If this instance
-        is a child, save only the keys/values in this child and leave parent
-        values unaltered."""
-        # Triggers a partial save targeting only this instance's keys.
-        if self._root_saver:
-            self._root_saver(self._key_path, self.to_dict())
+        """Save this node's scope back to file.
+
+        Root node writes the full tree; a child node merges only its scope
+        into the existing file, leaving sibling keys untouched.
+        """
+        path = self.filepath
+        full_data = _load_dict_from_file(path) if path.exists() else {}
+        if self.is_root:
+            full_data = self.to_dict()
         else:
-            self._save_partial()
+            _set_nested(full_data, self._path_from_root(), self.to_dict())
+        _dump_dict_to_file(path, full_data)

--- a/src/device_spinner/hierarchical_dict.py
+++ b/src/device_spinner/hierarchical_dict.py
@@ -1,0 +1,75 @@
+"""Hierarchical dict whose nested values are addressable as child nodes."""
+
+from collections import UserDict
+from typing import Any, Dict, List, Optional
+
+KeyPath = List[str]
+
+
+class HierarchicalDict(UserDict[str, Any]):
+    """A dict that recursively wraps nested plain dicts as child nodes of the same type.
+
+    Each node holds a reference to its parent, allowing any node to compute
+    its full key path from the root via ``_path_from_root()``. The class is
+    persistence-agnostic; subclasses can use the path information to implement
+    scoped save/load operations.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        _parent: Optional["HierarchicalDict"] = None,
+        _key_in_parent: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._parent: Optional["HierarchicalDict"] = _parent
+        self._key_in_parent: Optional[str] = _key_in_parent
+        super().__init__(dict(*args, **kwargs))
+        self._convert_nested()
+
+    def _make_child(self, key: str, value: Dict[str, Any]) -> "HierarchicalDict":
+        """Wrap a plain dict value as a child node. Subclasses override this
+        to produce child instances of their own type."""
+        return HierarchicalDict(value, _parent=self, _key_in_parent=key)
+
+    @property
+    def is_root(self) -> bool:
+        """True if this node has no parent."""
+        return self._parent is None
+
+    def _path_from_root(self) -> KeyPath:
+        """Return this node's key path from the root.
+
+        The root node returns an empty list. Non-root nodes always have a
+        string ``_key_in_parent`` assigned by ``_make_child``.
+        """
+        current: Optional["HierarchicalDict"] = self
+        path: KeyPath = []
+        while current is not None and current._parent is not None:
+            assert current._key_in_parent is not None
+            path.append(current._key_in_parent)
+            current = current._parent
+        path.reverse()
+        return path
+
+    def _convert_nested(self) -> None:
+        """Wrap plain dicts already in self.data as child nodes."""
+        for key, value in list(self.data.items()):
+            if isinstance(value, dict) and not isinstance(value, HierarchicalDict):
+                self.data[key] = self._make_child(key, value)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Wrap plain dict values as child nodes before storing."""
+        if isinstance(value, dict) and not isinstance(value, HierarchicalDict):
+            value = self._make_child(key, value)
+        super().__setitem__(key, value)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Recursively convert to a plain dict."""
+        result: Dict[str, Any] = {}
+        for key, value in self.data.items():
+            if isinstance(value, HierarchicalDict):
+                result[key] = value.to_dict()
+            else:
+                result[key] = value
+        return result

--- a/tests/test_file_backed_dict.py
+++ b/tests/test_file_backed_dict.py
@@ -1,5 +1,4 @@
-from device_spinner.hierarchical_dict import HierarchicalDict
-from device_spinner.file_backed_dict import FileBackedDict, load, save
+from device_spinner.file_backed_dict import FileBackedDict
 
 
 def get_example_file_backed_dict(tmp_path) -> FileBackedDict:
@@ -129,27 +128,26 @@ def test_parent_pointers_compute_child_path_and_save_scope(tmp_path):
 
 def test_module_load_save_round_trip_root(tmp_path):
     path = tmp_path / "config.yaml"
-    cfg = HierarchicalDict({"database": {"host": "localhost", "port": 5432}})
-    save(cfg, path)
+    cfg = FileBackedDict.init_root(path)
+    cfg["database"] = {"host": "localhost", "port": 5432}
+    cfg.save()
 
-    loaded = load(path)
-    assert isinstance(loaded, HierarchicalDict)
-    assert loaded.to_dict() == {"database": {"host": "localhost", "port": 5432}}
+    reloaded = FileBackedDict.init_root(path)
+    assert reloaded.to_dict() == {"database": {"host": "localhost", "port": 5432}}
 
 
 def test_module_save_child_scope_only(tmp_path):
     path = tmp_path / "config.yaml"
-    root = HierarchicalDict(
-        {"users": {"Fred": {"fave_recipe": {"name": "fried strings"}}}}
-    )
-    save(root, path)
+    root = FileBackedDict.init_root(path)
+    root["users"] = {"Fred": {"fave_recipe": {"name": "fried strings"}}}
+    root.save()
 
     child = root["users"]["Fred"]["fave_recipe"]
     child["name"] = "tomato soup"
     root["users"]["Frankie"] = {"fave_recipe": {"name": "onion soup"}}
 
-    save(child, path)
+    child.save()
 
-    reloaded = load(path)
+    reloaded = FileBackedDict.init_root(path)
     assert reloaded["users"]["Fred"]["fave_recipe"]["name"] == "tomato soup"
     assert "Frankie" not in reloaded["users"]

--- a/tests/test_file_backed_dict.py
+++ b/tests/test_file_backed_dict.py
@@ -4,7 +4,7 @@ from device_spinner.file_backed_dict import FileBackedDict
 def get_example_file_backed_dict(tmp_path) -> FileBackedDict:
     """Make a FileBackedDict instance from an empty config.yaml file"""
     path = tmp_path / "config.yaml"  # Empty yaml.
-    config = FileBackedDict.init_root(path)
+    config = FileBackedDict(filepath=path)
     config["users"] = {
         "Fred": {
             "age": 42,
@@ -20,7 +20,7 @@ def get_example_file_backed_dict(tmp_path) -> FileBackedDict:
 
 def test_to_dict_comparison(tmp_path):
     path = tmp_path / "config.yaml"  # Empty yaml.
-    config = FileBackedDict.init_root(path)
+    config = FileBackedDict(filepath=path)
     config["database"] = {"host": "localhost", "port": 5432}
     config["logging"] = {"level": "INFO"}
 
@@ -53,11 +53,11 @@ def test_child_altering_attributes_changes_same_attributes_in_parent(tmp_path):
 
 def test_saving(tmp_path):
     path = tmp_path / "config.yaml"  # Empty yaml.
-    config = FileBackedDict.init_root(path)
+    config = FileBackedDict(filepath=path)
     config["pockets"] = ["keys", "spare change", "the one ring"]
     config.save()
     # Import changes from file into a separate instance.
-    config2 = FileBackedDict.init_root(path)
+    config2 = FileBackedDict(filepath=path)
     assert config2.to_dict() == config.to_dict()
 
 
@@ -79,7 +79,7 @@ def test_saving_child_only_saves_child_scope_changes(tmp_path):
     freds_fave_recipe.save()  # should not save out-of-scope changes.
     # Import changes from file into a separate instance.
     path = tmp_path / "config.yaml"  # recently-saved yaml
-    config2 = FileBackedDict.init_root(path)
+    config2 = FileBackedDict(filepath=path)
     assert "Frankie" not in config2.to_dict()["users"]
 
 
@@ -104,14 +104,14 @@ def test_saving_parent_also_saves_child_scope_changes(tmp_path):
     config.save()  # should save everything.
     # Import changes from file into a separate instance.
     path = tmp_path / "config.yaml"  # recently-saved yaml
-    config2 = FileBackedDict.init_root(path)
+    config2 = FileBackedDict(filepath=path)
     # Child changes should exist.
     assert config2["users"]["Fred"]["fave_recipe"]["name"] == "string beans"
 
 
 def test_parent_pointers_compute_child_path_and_save_scope(tmp_path):
     path = tmp_path / "config.yaml"
-    config = FileBackedDict.init_root(path)
+    config = FileBackedDict(filepath=path)
     config["root"] = {"child": {"leaf": {"value": 1}}}
 
     leaf = config["root"]["child"]["leaf"]
@@ -121,24 +121,24 @@ def test_parent_pointers_compute_child_path_and_save_scope(tmp_path):
     config["unsaved_sibling"] = {"x": 1}
     leaf.save()
 
-    reloaded = FileBackedDict.init_root(path)
+    reloaded = FileBackedDict(filepath=path)
     assert reloaded["root"]["child"]["leaf"]["value"] == 2
     assert "unsaved_sibling" not in reloaded
 
 
 def test_module_load_save_round_trip_root(tmp_path):
     path = tmp_path / "config.yaml"
-    cfg = FileBackedDict.init_root(path)
+    cfg = FileBackedDict(filepath=path)
     cfg["database"] = {"host": "localhost", "port": 5432}
     cfg.save()
 
-    reloaded = FileBackedDict.init_root(path)
+    reloaded = FileBackedDict(filepath=path)
     assert reloaded.to_dict() == {"database": {"host": "localhost", "port": 5432}}
 
 
 def test_module_save_child_scope_only(tmp_path):
     path = tmp_path / "config.yaml"
-    root = FileBackedDict.init_root(path)
+    root = FileBackedDict(filepath=path)
     root["users"] = {"Fred": {"fave_recipe": {"name": "fried strings"}}}
     root.save()
 
@@ -148,6 +148,44 @@ def test_module_save_child_scope_only(tmp_path):
 
     child.save()
 
-    reloaded = FileBackedDict.init_root(path)
+    reloaded = FileBackedDict(filepath=path)
     assert reloaded["users"]["Fred"]["fave_recipe"]["name"] == "tomato soup"
     assert "Frankie" not in reloaded["users"]
+
+
+def test_load_replaces_in_memory_values(tmp_path):
+    path = tmp_path / "config.yaml"
+    config = FileBackedDict(filepath=path)
+    config["x"] = 1
+    config.save()
+
+    # Mutate in memory without saving, then reload.
+    config["x"] = 99
+    config["y"] = "stale"
+    config.load()
+
+    assert config["x"] == 1
+    assert "y" not in config
+
+
+def test_load_replace_false_merges_file_on_top(tmp_path):
+    path = tmp_path / "config.yaml"
+    config = FileBackedDict(filepath=path)
+    config["x"] = 1
+    config.save()
+
+    config["x"] = 99  # unsaved change
+    config["y"] = "local-only"
+    config.load(replace=False)
+
+    assert config["x"] == 1  # file value wins
+    assert config["y"] == "local-only"  # local-only key survives
+
+
+def test_is_root(tmp_path):
+    path = tmp_path / "config.yaml"
+    config = FileBackedDict(filepath=path)
+    config["nested"] = {"key": "value"}
+
+    assert config.is_root is True
+    assert config["nested"].is_root is False

--- a/tests/test_file_backed_dict.py
+++ b/tests/test_file_backed_dict.py
@@ -1,27 +1,34 @@
-from _pytest.nodes import File
-from device_spinner.file_backed_dict import FileBackedDict
+from device_spinner.hierarchical_dict import HierarchicalDict
+from device_spinner.file_backed_dict import FileBackedDict, load, save
 
 
 def get_example_file_backed_dict(tmp_path) -> FileBackedDict:
     """Make a FileBackedDict instance from an empty config.yaml file"""
     path = tmp_path / "config.yaml"  # Empty yaml.
-    config = FileBackedDict(path)
-    config["users"] = {"Fred": {"age": 42,
-                                "fave_recipe": {"name": "fried strings",
-                                                "ingredients": ["string", "strfry"],
-                                                "instructions": ["Saute the string.",
-                                                                 "Cool and serve."]}}}
+    config = FileBackedDict.init_root(path)
+    config["users"] = {
+        "Fred": {
+            "age": 42,
+            "fave_recipe": {
+                "name": "fried strings",
+                "ingredients": ["string", "strfry"],
+                "instructions": ["Saute the string.", "Cool and serve."],
+            },
+        }
+    }
     return config
 
 
 def test_to_dict_comparison(tmp_path):
     path = tmp_path / "config.yaml"  # Empty yaml.
-    config = FileBackedDict(path)
+    config = FileBackedDict.init_root(path)
     config["database"] = {"host": "localhost", "port": 5432}
     config["logging"] = {"level": "INFO"}
 
-    config_dict = {"database":{"host": "localhost", "port": 5432},
-                   "logging": {"level": "INFO"}}
+    config_dict = {
+        "database": {"host": "localhost", "port": 5432},
+        "logging": {"level": "INFO"},
+    }
     assert config.to_dict() == config_dict
 
 
@@ -47,11 +54,11 @@ def test_child_altering_attributes_changes_same_attributes_in_parent(tmp_path):
 
 def test_saving(tmp_path):
     path = tmp_path / "config.yaml"  # Empty yaml.
-    config = FileBackedDict(path)
+    config = FileBackedDict.init_root(path)
     config["pockets"] = ["keys", "spare change", "the one ring"]
     config.save()
     # Import changes from file into a separate instance.
-    config2 = FileBackedDict(path)
+    config2 = FileBackedDict.init_root(path)
     assert config2.to_dict() == config.to_dict()
 
 
@@ -62,15 +69,18 @@ def test_saving_child_only_saves_child_scope_changes(tmp_path):
     # Alter child
     freds_fave_recipe["name"] = "tomato soup"
     # Alter parent
-    config["users"]["Frankie"] = {"age": 27,
-                                  "fave_recipe": {"name": "onion soup",
-                                                  "ingredients": ["onions", "broth"],
-                                                  "instructions": ["boil for 10 mins.",
-                                                                   "Cool and serve."]}}
-    freds_fave_recipe.save() # should not save out-of-scope changes.
+    config["users"]["Frankie"] = {
+        "age": 27,
+        "fave_recipe": {
+            "name": "onion soup",
+            "ingredients": ["onions", "broth"],
+            "instructions": ["boil for 10 mins.", "Cool and serve."],
+        },
+    }
+    freds_fave_recipe.save()  # should not save out-of-scope changes.
     # Import changes from file into a separate instance.
     path = tmp_path / "config.yaml"  # recently-saved yaml
-    config2 = FileBackedDict(path)
+    config2 = FileBackedDict.init_root(path)
     assert "Frankie" not in config2.to_dict()["users"]
 
 
@@ -81,17 +91,65 @@ def test_saving_parent_also_saves_child_scope_changes(tmp_path):
     # Alter child
     freds_fave_recipe["name"] = "tomato soup"
     # Alter parent
-    config["users"]["Frankie"] = {"age": 27,
-                                  "fave_recipe": {"name": "onion soup",
-                                                  "ingredients": ["onions", "broth"],
-                                                  "instructions": ["boil for 10 mins.",
-                                                                   "Cool and serve."]}}
+    config["users"]["Frankie"] = {
+        "age": 27,
+        "fave_recipe": {
+            "name": "onion soup",
+            "ingredients": ["onions", "broth"],
+            "instructions": ["boil for 10 mins.", "Cool and serve."],
+        },
+    }
     # Alter child
     freds_fave_recipe["name"] = "string beans"
     # Save parent
-    config.save() # should save everything.
+    config.save()  # should save everything.
     # Import changes from file into a separate instance.
     path = tmp_path / "config.yaml"  # recently-saved yaml
-    config2 = FileBackedDict(path)
+    config2 = FileBackedDict.init_root(path)
     # Child changes should exist.
     assert config2["users"]["Fred"]["fave_recipe"]["name"] == "string beans"
+
+
+def test_parent_pointers_compute_child_path_and_save_scope(tmp_path):
+    path = tmp_path / "config.yaml"
+    config = FileBackedDict.init_root(path)
+    config["root"] = {"child": {"leaf": {"value": 1}}}
+
+    leaf = config["root"]["child"]["leaf"]
+    assert leaf._path_from_root() == ["root", "child", "leaf"]
+
+    leaf["value"] = 2
+    config["unsaved_sibling"] = {"x": 1}
+    leaf.save()
+
+    reloaded = FileBackedDict.init_root(path)
+    assert reloaded["root"]["child"]["leaf"]["value"] == 2
+    assert "unsaved_sibling" not in reloaded
+
+
+def test_module_load_save_round_trip_root(tmp_path):
+    path = tmp_path / "config.yaml"
+    cfg = HierarchicalDict({"database": {"host": "localhost", "port": 5432}})
+    save(cfg, path)
+
+    loaded = load(path)
+    assert isinstance(loaded, HierarchicalDict)
+    assert loaded.to_dict() == {"database": {"host": "localhost", "port": 5432}}
+
+
+def test_module_save_child_scope_only(tmp_path):
+    path = tmp_path / "config.yaml"
+    root = HierarchicalDict(
+        {"users": {"Fred": {"fave_recipe": {"name": "fried strings"}}}}
+    )
+    save(root, path)
+
+    child = root["users"]["Fred"]["fave_recipe"]
+    child["name"] = "tomato soup"
+    root["users"]["Frankie"] = {"fave_recipe": {"name": "onion soup"}}
+
+    save(child, path)
+
+    reloaded = load(path)
+    assert reloaded["users"]["Fred"]["fave_recipe"]["name"] == "tomato soup"
+    assert "Frankie" not in reloaded["users"]


### PR DESCRIPTION
So it felt like FileBackedDict was doing multiple things, and I wanted to pull the hierarchical part and node-traversal into its own thing. I also replaced the `_root_saver` callable-passing with a straight reference to the parent, so calling `save` will just go find the filepath from the root.

With help from Claude.